### PR TITLE
Add migration helper files for CustomerType enum

### DIFF
--- a/alembic_migration_example.py
+++ b/alembic_migration_example.py
@@ -1,0 +1,64 @@
+"""Example of corrected Alembic migration
+
+Replace your c0d3b6ad53b2_added_international_status.py with this content
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'c0d3b6ad53b2'
+down_revision = None  # Replace with your previous migration ID
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create customertype enum if it doesn't exist
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE customertype AS ENUM ('default', 'international');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Add type column to customer table
+    op.add_column('customer',
+        sa.Column('type',
+                  postgresql.ENUM('default', 'international', name='customertype', create_type=False),
+                  nullable=True)
+    )
+
+    # Create index for customer type
+    op.create_index('idx_customer_type', 'customer', ['type'], unique=False, if_not_exists=True)
+
+    # Add international_sales to PageName enum
+    op.execute("""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_enum
+                WHERE enumlabel = 'international_sales'
+                AND enumtypid = (
+                    SELECT oid FROM pg_type WHERE typname = 'pagename'
+                )
+            ) THEN
+                ALTER TYPE pagename ADD VALUE 'international_sales';
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade():
+    # Remove index
+    op.drop_index('idx_customer_type', table_name='customer', if_exists=True)
+
+    # Remove column
+    op.drop_column('customer', 'type')
+
+    # Drop enum type
+    op.execute("DROP TYPE IF EXISTS customertype")
+
+    # Note: Cannot remove value from pagename enum (PostgreSQL limitation)
+    # Manual intervention required to remove 'international_sales' from pagename enum

--- a/verify_migration.sql
+++ b/verify_migration.sql
@@ -1,0 +1,16 @@
+-- Verify the customer type column exists
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'customer' AND column_name = 'type';
+
+-- Verify customertype enum exists
+SELECT enumlabel
+FROM pg_enum
+WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'customertype')
+ORDER BY enumsortorder;
+
+-- Verify international_sales in PageName enum
+SELECT enumlabel
+FROM pg_enum
+WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'pagename')
+ORDER BY enumsortorder;


### PR DESCRIPTION
- alembic_migration_example.py: Example showing how to fix Alembic migration
- verify_migration.sql: SQL script to verify migration success

These files help resolve the Alembic migration error where customertype enum was used before being created. The manual SQL migration in migrations/003_*.sql is the recommended approach.