### PR TITLE
Change customer type from default to local, remove international_sale…

### DIFF
--- a/alembic_migration_example.py
+++ b/alembic_migration_example.py
@@ -1,6 +1,6 @@
 """Example of corrected Alembic migration
 
-Replace your c0d3b6ad53b2_added_international_status.py with this content
+Replace your auto-generated migration file with this content if you prefer to use Alembic
 """
 
 from alembic import op
@@ -8,7 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = 'c0d3b6ad53b2'
+revision = 'REPLACE_WITH_YOUR_REVISION'
 down_revision = None  # Replace with your previous migration ID
 branch_labels = None
 depends_on = None
@@ -18,7 +18,7 @@ def upgrade():
     # Create customertype enum if it doesn't exist
     op.execute("""
         DO $$ BEGIN
-            CREATE TYPE customertype AS ENUM ('default', 'international');
+            CREATE TYPE customertype AS ENUM ('local', 'international');
         EXCEPTION
             WHEN duplicate_object THEN null;
         END $$;
@@ -27,27 +27,12 @@ def upgrade():
     # Add type column to customer table
     op.add_column('customer',
         sa.Column('type',
-                  postgresql.ENUM('default', 'international', name='customertype', create_type=False),
+                  postgresql.ENUM('local', 'international', name='customertype', create_type=False),
                   nullable=True)
     )
 
     # Create index for customer type
     op.create_index('idx_customer_type', 'customer', ['type'], unique=False, if_not_exists=True)
-
-    # Add international_sales to PageName enum
-    op.execute("""
-        DO $$ BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_enum
-                WHERE enumlabel = 'international_sales'
-                AND enumtypid = (
-                    SELECT oid FROM pg_type WHERE typname = 'pagename'
-                )
-            ) THEN
-                ALTER TYPE pagename ADD VALUE 'international_sales';
-            END IF;
-        END $$;
-    """)
 
 
 def downgrade():
@@ -59,6 +44,3 @@ def downgrade():
 
     # Drop enum type
     op.execute("DROP TYPE IF EXISTS customertype")
-
-    # Note: Cannot remove value from pagename enum (PostgreSQL limitation)
-    # Manual intervention required to remove 'international_sales' from pagename enum

--- a/models/admin_models.py
+++ b/models/admin_models.py
@@ -44,7 +44,7 @@ class ConversationLanguage(enum.Enum):
 
 class CustomerType(enum.Enum):
     """Customer type for filtering"""
-    default = "default"  # Default/local customers
+    local = "local"  # Local customers
     international = "international"  # International customers
 
 # 1. Payment table
@@ -87,7 +87,7 @@ customer = Table(
     Column("phone_number", String(500), nullable=False),
     Column("status", Enum(CustomerStatus), nullable=False),
     Column("status_name", String(100), nullable=True),  # NEW: Dynamic status from customer_status table (optional, for custom statuses)
-    Column("type", Enum(CustomerType), nullable=True, default=None),  # NEW: Customer type (default/international)
+    Column("type", Enum(CustomerType), nullable=True, default=None),  # NEW: Customer type (local/international)
     Column("assistant_name", String(255), nullable=True),
     Column("notes", Text, nullable=True),
     Column("audio_file_id", String(500), nullable=True),  # Telegram file ID

--- a/models/user_models.py
+++ b/models/user_models.py
@@ -23,7 +23,6 @@ class PageName(enum.Enum):
     crm = "crm"
     finance_list = "finance_list"
     update_list = "update_list"
-    international_sales = "international_sales"  # NEW: International sales page
 
 
 

--- a/routers/crm.py
+++ b/routers/crm.py
@@ -412,7 +412,7 @@ async def create_customer(
         username: Optional[str] = Form(None),
         assistant_name: Optional[str] = Form(None),
         notes: Optional[str] = Form(None),
-        customer_type: Optional[str] = Form(None),  # NEW: Customer type (default/international)
+        customer_type: Optional[str] = Form(None),  # NEW: Customer type (local/international)
         conversation_language: Optional[ConversationLanguageEnum] = Form(ConversationLanguageEnum.UZ),
         audio: Optional[UploadFile] = File(None),
         session: AsyncSession = Depends(get_async_session),
@@ -421,7 +421,7 @@ async def create_customer(
     """
     Yangi mijoz yaratish - barcha audio formatlar bilan (MP3, OGG, WAV, M4A, ...)
     Status: dinamik status name (string) - masalan: "contacted", "project_started", va hokazo
-    Type: "default" (local) yoki "international" - default null
+    Type: "local" yoki "international" - default null
     """
     # Huquq tekshiruvi
     permissions_result = await session.execute(
@@ -486,8 +486,8 @@ async def create_customer(
     if customer_type:
         if customer_type.lower() == "international":
             parsed_type = CustomerType.international
-        elif customer_type.lower() == "default":
-            parsed_type = CustomerType.default
+        elif customer_type.lower() == "local":
+            parsed_type = CustomerType.local
 
     # Mijozni yaratish
     customer_dict = {
@@ -497,7 +497,7 @@ async def create_customer(
         "phone_number": encrypted_phone,
         "status": CustomerStatus.contacted,  # Default enum for backward compatibility
         "status_name": status_name,  # NEW: Dynamic status name
-        "type": parsed_type,  # NEW: Customer type (default/international)
+        "type": parsed_type,  # NEW: Customer type (local/international)
         "assistant_name": assistant_name,
         "notes": notes,
         "audio_file_id": audio_file_id,


### PR DESCRIPTION
…s page

Major Changes:
1. CustomerType enum: 'default' → 'local' (international remains)
2. Removed 'international_sales' from PageName enum
3. All customer types are now managed in single CRM page with filtering

Details:
- models/admin_models.py: CustomerType.default → CustomerType.local
- models/user_models.py: Removed PageName.international_sales
- routers/crm.py: Updated customer type parsing to use 'local'
- routers/sales_stats.py: Updated filtering logic and removed international_sales permission check
- migrations/003_*.sql: Updated enum to ('local', 'international')
- alembic_migration_example.py: Updated example to match new structure

API Changes:
- POST /crm/customers: customer_type accepts "local" or "international"
- GET /sales/stats: customer_type filter accepts "local" or "international"
- NULL values in customer.type are treated as "local" for backward compatibility
- All leads visible in CRM page regardless of type

This change simplifies the system by having one unified CRM page where users can filter by customer type (local vs international) rather than separate pages.