### PR TITLE
Fix authentication error when no token provided

### DIFF
--- a/auth_utils/auth_func.py
+++ b/auth_utils/auth_func.py
@@ -46,6 +46,14 @@ async def get_current_user(
     session: AsyncSession = Depends(get_async_session)
 ):
     """Foydalanuvchini token orqali aniqlash"""
+    # Check if credentials exist
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token yuborilmagan. Authorization header kerak.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     token = credentials.credentials
 
     credentials_exception = HTTPException(


### PR DESCRIPTION
Issue:
- AttributeError when accessing endpoint without Authorization header
- credentials was None but code tried to access credentials.credentials

Fix:
- Added None check before accessing credentials.credentials
- Now returns proper 401 error with clear message: "Token yuborilmagan"

Before: AttributeError crash
After: Proper HTTP 401 Unauthorized response

This fixes the error when:
- User forgets to add Authorization header
- Frontend makes request without token
- Testing endpoints without authentication