### PR TITLE
Add separate chat IDs for audio and update bots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,15 +13,17 @@ SECRET_KEY=uzbekiston-juda-xavfsiz-kalit-1234567890
 # Telegram Bot Configuration
 # IMPORTANT: 2 ta alohida bot - har biri uchun alohida token!
 
-# 1. AUDIO BOT - Audio fayllarni yuklash uchun
+# 1. AUDIO BOT - Audio fayllarni guruhga yuklash uchun
 # Get token from @BotFather (masalan: @your_audio_bot)
 TELEGRAM_AUDIO_BOT_TOKEN=your_audio_bot_token_here
-# Chat ID where audio files will be sent (can be group ID or channel ID)
-TELEGRAM_CHAT_ID=your_chat_id_here
+# Chat ID where audio files will be sent (guruh yoki kanal ID)
+TELEGRAM_AUDIO_CHAT_ID=your_audio_chat_id_here
 
-# 2. UPDATE BOT - Webhook va yangilanishlarni qabul qilish uchun
+# 2. UPDATE BOT - Guruhdan yangilanishlarni o'qish uchun
 # Get token from @BotFather (masalan: @your_update_bot)
 TELEGRAM_UPDATE_BOT_TOKEN=your_update_bot_token_here
+# Chat ID where bot reads daily updates (guruh ID - yangilanishlar yoziladigan guruh)
+TELEGRAM_UPDATE_CHAT_ID=your_update_chat_id_here
 # Your domain for webhook setup (e.g., https://yourdomain.com)
 WEBHOOK_URL=https://your-domain.com
 

--- a/TELEGRAM_BOT_SETUP.md
+++ b/TELEGRAM_BOT_SETUP.md
@@ -72,7 +72,11 @@ Group Privacy - DISABLE (Guruh xabarlarini o'qish uchun)
 
 **Eslatma:** Audio bot uchun bu sozlama shart emas (u faqat xabar yuboradi)
 
-### 3-qadam: Chat ID ni oling
+### 4-qadam: Chat ID larni oling
+
+Har bir bot uchun o'z guruhining ID sini olish kerak (yoki bir xil guruh bo'lsa, bir xil ID ishlatsa bo'ladi).
+
+#### Audio Bot Chat ID (TELEGRAM_AUDIO_CHAT_ID)
 
 **Opsiya A: Guruh uchun**
 
@@ -97,6 +101,21 @@ Group Privacy - DISABLE (Guruh xabarlarini o'qish uchun)
 1. [@userinfobot](https://t.me/userinfobot) ga `/start` yuboring
 2. Sizning Chat ID ni ko'rsatadi
 
+#### Update Bot Chat ID (TELEGRAM_UPDATE_CHAT_ID)
+
+Update bot kunlik yangilanishlar yoziladigan guruhda ishlaydi.
+
+1. **Update botni** yangilanishlar guruhiga qo'shing
+2. Guruhda biror xabar yozing
+3. Brauzerda oching:
+   ```
+   https://api.telegram.org/bot<UPDATE_BOT_TOKEN>/getUpdates
+   ```
+4. `"chat":{"id":-1001234567890` ni toping
+5. Bu TELEGRAM_UPDATE_CHAT_ID bo'ladi
+
+**Muhim:** Agar audio va update botlar bir xil guruhda ishlaydigan bo'lsa, bir xil Chat ID ni ikkala joyga ham qo'yishingiz mumkin.
+
 ---
 
 ## ⚙️ Sozlash
@@ -110,10 +129,11 @@ Group Privacy - DISABLE (Guruh xabarlarini o'qish uchun)
 
 # 1. AUDIO BOT - Audio fayllarni yuklash uchun
 TELEGRAM_AUDIO_BOT_TOKEN=1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
-TELEGRAM_CHAT_ID=-1001234567890  # Audio yuborilayotgan guruh/kanal ID
+TELEGRAM_AUDIO_CHAT_ID=-1001234567890  # Audio yuborilayotgan guruh/kanal ID
 
 # 2. UPDATE BOT - Webhook va yangilanishlarni qabul qilish uchun
 TELEGRAM_UPDATE_BOT_TOKEN=0987654321:ZYXwvuTSRqponMLKjihGFEdcba
+TELEGRAM_UPDATE_CHAT_ID=-1002345678901  # Yangilanishlar o'qilayotgan guruh ID
 WEBHOOK_URL=https://your-domain.com  # Server domeningiz (HTTPS!)
 ```
 
@@ -121,8 +141,11 @@ WEBHOOK_URL=https://your-domain.com  # Server domeningiz (HTTPS!)
 
 - `TELEGRAM_AUDIO_BOT_TOKEN` - Audio bot uchun token (1-bot)
 - `TELEGRAM_UPDATE_BOT_TOKEN` - Update bot uchun token (2-bot)
-- `TELEGRAM_CHAT_ID` - Audio yuborilayotgan guruh/kanal ID (manfiy raqam)
+- `TELEGRAM_AUDIO_CHAT_ID` - Audio yuborilayotgan guruh/kanal ID (manfiy raqam)
+- `TELEGRAM_UPDATE_CHAT_ID` - Yangilanishlar o'qilayotgan guruh ID (manfiy raqam)
 - `WEBHOOK_URL` - Server domeni (HTTPS bo'lishi shart!)
+
+**Eslatma:** Agar ikkala bot ham bir xil guruhda ishlasa, `TELEGRAM_AUDIO_CHAT_ID` va `TELEGRAM_UPDATE_CHAT_ID` bir xil bo'lishi mumkin.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -40,9 +40,16 @@ PASSWORD_RESET_EXPIRE_MINUTES = 30
 
 
 # Telegram Bot Tokens - 2 ta alohida bot
-TELEGRAM_AUDIO_BOT_TOKEN = os.environ.get('TELEGRAM_AUDIO_BOT_TOKEN')  # Audio yuklash uchun
-TELEGRAM_UPDATE_BOT_TOKEN = os.environ.get('TELEGRAM_UPDATE_BOT_TOKEN')  # Webhook/update parser uchun
-TELEGRAM_CHAT_ID = os.environ.get('TELEGRAM_CHAT_ID')  # Audio yuborilayotgan chat ID
+TELEGRAM_AUDIO_BOT_TOKEN = os.environ.get('TELEGRAM_AUDIO_BOT_TOKEN')  # Audio bot tokeni
+TELEGRAM_UPDATE_BOT_TOKEN = os.environ.get('TELEGRAM_UPDATE_BOT_TOKEN')  # Update bot tokeni
+
+# Telegram Chat IDs - har bir bot uchun alohida guruh
+TELEGRAM_AUDIO_CHAT_ID = os.environ.get('TELEGRAM_AUDIO_CHAT_ID')  # Audio yuborilayotgan guruh ID
+TELEGRAM_UPDATE_CHAT_ID = os.environ.get('TELEGRAM_UPDATE_CHAT_ID')  # Yangilanishlar o'qilayotgan guruh ID
+
+# Backward compatibility uchun (eski kod ishlab turishi uchun)
+TELEGRAM_CHAT_ID = TELEGRAM_AUDIO_CHAT_ID  # Default: audio chat ID
+
 WEBHOOK_URL = os.environ.get('WEBHOOK_URL')  # Webhook URL
 
 

--- a/test_bots.py
+++ b/test_bots.py
@@ -17,7 +17,8 @@ load_dotenv()
 # Konfiguratsiya - 2 ta alohida bot
 TELEGRAM_AUDIO_BOT_TOKEN = os.getenv('TELEGRAM_AUDIO_BOT_TOKEN')
 TELEGRAM_UPDATE_BOT_TOKEN = os.getenv('TELEGRAM_UPDATE_BOT_TOKEN')
-TELEGRAM_CHAT_ID = os.getenv('TELEGRAM_CHAT_ID')
+TELEGRAM_AUDIO_CHAT_ID = os.getenv('TELEGRAM_AUDIO_CHAT_ID')
+TELEGRAM_UPDATE_CHAT_ID = os.getenv('TELEGRAM_UPDATE_CHAT_ID')
 
 
 async def test_audio_bot():
@@ -31,9 +32,9 @@ async def test_audio_bot():
         print("   @BotFather dan audio bot uchun token oling")
         return False
 
-    if not TELEGRAM_CHAT_ID:
-        print("❌ XATO: TELEGRAM_CHAT_ID .env faylida topilmadi!")
-        print("   Guruh yoki kanal ID sini .env ga qo'shing")
+    if not TELEGRAM_AUDIO_CHAT_ID:
+        print("❌ XATO: TELEGRAM_AUDIO_CHAT_ID .env faylida topilmadi!")
+        print("   Audio yuborilayotgan guruh/kanal ID sini .env ga qo'shing")
         return False
 
     try:
@@ -55,17 +56,17 @@ async def test_audio_bot():
 
         # Test xabari yuborish
         print(f"\n📤 Test xabarini yuborish...")
-        print(f"   Chat ID: {TELEGRAM_CHAT_ID}")
+        print(f"   Chat ID: {TELEGRAM_AUDIO_CHAT_ID}")
 
         message = await bot.send_message(
-            chat_id=TELEGRAM_CHAT_ID,
+            chat_id=TELEGRAM_AUDIO_CHAT_ID,
             text="🎵 Audio Bot Test\n\nBot muvaffaqiyatli ishlamoqda!\nAudio fayllarni yuborish tayyor."
         )
 
         print(f"✅ Xabar yuborildi! Message ID: {message.message_id}")
 
         # Chat ma'lumotlarini ko'rsatish
-        chat = await bot.get_chat(chat_id=TELEGRAM_CHAT_ID)
+        chat = await bot.get_chat(chat_id=TELEGRAM_AUDIO_CHAT_ID)
         print(f"\n📊 Chat ma'lumotlari:")
         print(f"   Turi: {chat.type}")
         if chat.title:
@@ -259,7 +260,8 @@ async def check_environment():
     env_vars = {
         'TELEGRAM_AUDIO_BOT_TOKEN': TELEGRAM_AUDIO_BOT_TOKEN,
         'TELEGRAM_UPDATE_BOT_TOKEN': TELEGRAM_UPDATE_BOT_TOKEN,
-        'TELEGRAM_CHAT_ID': TELEGRAM_CHAT_ID,
+        'TELEGRAM_AUDIO_CHAT_ID': TELEGRAM_AUDIO_CHAT_ID,
+        'TELEGRAM_UPDATE_CHAT_ID': TELEGRAM_UPDATE_CHAT_ID,
         'WEBHOOK_URL': os.getenv('WEBHOOK_URL'),
         'DB_NAME': os.getenv('DB_NAME'),
         'DB_HOST': os.getenv('DB_HOST'),
@@ -277,15 +279,16 @@ async def check_environment():
 
         print(f"{status} {key:30} = {display_value}")
 
-        if not value and key in ['TELEGRAM_AUDIO_BOT_TOKEN', 'TELEGRAM_UPDATE_BOT_TOKEN', 'TELEGRAM_CHAT_ID']:
+        if not value and key in ['TELEGRAM_AUDIO_BOT_TOKEN', 'TELEGRAM_UPDATE_BOT_TOKEN', 'TELEGRAM_AUDIO_CHAT_ID', 'TELEGRAM_UPDATE_CHAT_ID']:
             all_ok = False
 
     if not all_ok:
         print(f"\n⚠️  Ba'zi muhim o'zgaruvchilar o'rnatilmagan!")
         print(f"   .env faylini to'ldiring:")
-        print(f"   - TELEGRAM_AUDIO_BOT_TOKEN (audio yuklash uchun)")
-        print(f"   - TELEGRAM_UPDATE_BOT_TOKEN (webhook/update uchun)")
-        print(f"   - TELEGRAM_CHAT_ID (guruh ID)")
+        print(f"   - TELEGRAM_AUDIO_BOT_TOKEN (audio bot tokeni)")
+        print(f"   - TELEGRAM_UPDATE_BOT_TOKEN (update bot tokeni)")
+        print(f"   - TELEGRAM_AUDIO_CHAT_ID (audio yuborilayotgan guruh ID)")
+        print(f"   - TELEGRAM_UPDATE_CHAT_ID (yangilanishlar o'qilayotgan guruh ID)")
 
     return all_ok
 

--- a/utils/telegram_helper.py
+++ b/utils/telegram_helper.py
@@ -3,7 +3,7 @@ from telegram.error import TelegramError
 from telegram.request import HTTPXRequest
 from fastapi import UploadFile, HTTPException
 import io
-from config import TELEGRAM_AUDIO_BOT_TOKEN, TELEGRAM_CHAT_ID
+from config import TELEGRAM_AUDIO_BOT_TOKEN, TELEGRAM_AUDIO_CHAT_ID
 
 # Timeout sozlamalarini oshirish
 request = HTTPXRequest(
@@ -38,7 +38,7 @@ async def upload_audio_to_telegram(audio_file: UploadFile) -> str:
         # OGG va OPUS formatlar uchun send_voice ishlatish
         if file_extension in ['ogg', 'opus', 'oga'] or 'ogg' in content_type:
             message = await bot.send_voice(
-                chat_id=TELEGRAM_CHAT_ID,
+                chat_id=TELEGRAM_AUDIO_CHAT_ID,
                 voice=io.BytesIO(audio_content),
                 filename=audio_file.filename or 'audio.ogg',
                 read_timeout=180,    # 3 daqiqa
@@ -49,7 +49,7 @@ async def upload_audio_to_telegram(audio_file: UploadFile) -> str:
         # MP3, M4A, WAV, FLAC uchun send_audio
         elif file_extension in ['mp3', 'm4a', 'wav', 'flac', 'aac', 'wma']:
             message = await bot.send_audio(
-                chat_id=TELEGRAM_CHAT_ID,
+                chat_id=TELEGRAM_AUDIO_CHAT_ID,
                 audio=io.BytesIO(audio_content),
                 filename=audio_file.filename or 'audio.mp3',
                 title=audio_file.filename or 'Audio File',
@@ -61,7 +61,7 @@ async def upload_audio_to_telegram(audio_file: UploadFile) -> str:
         # Noma'lum formatlar uchun send_document
         else:
             message = await bot.send_document(
-                chat_id=TELEGRAM_CHAT_ID,
+                chat_id=TELEGRAM_AUDIO_CHAT_ID,
                 document=io.BytesIO(audio_content),
                 filename=audio_file.filename or 'audio_file',
                 read_timeout=180,    # 3 daqiqa


### PR DESCRIPTION
Har bir bot uchun alohida chat ID:

1. Environment Variables:
   - TELEGRAM_AUDIO_CHAT_ID - audio yuborilayotgan guruh
   - TELEGRAM_UPDATE_CHAT_ID - yangilanishlar o'qilayotgan guruh
   - Eski TELEGRAM_CHAT_ID backward compatibility uchun qoldirildi

2. Config Updates:
   - config.py: 2 ta alohida chat ID qo'shildi
   - TELEGRAM_CHAT_ID = TELEGRAM_AUDIO_CHAT_ID (default)
   - Har bir bot o'z guruhida ishlaydi

3. Code Updates:
   - telegram_helper.py: TELEGRAM_AUDIO_CHAT_ID ishlatadi
   - test_bots.py: ikkala chat ID ham tekshiriladi
   - Barcha joyda tegishli chat ID ishlatiladi

4. Documentation:
   - TELEGRAM_BOT_SETUP.md: har bir chat ID uchun yo'riqnoma
   - Chat ID olish bo'yicha aniq ko'rsatmalar
   - Bir xil guruh uchun eslatma qo'shildi

Endi har bir bot o'z guruhida mustaqil ishlaydi!
Yoki kerak bo'lsa, ikkala bot ham bir xil guruhda ishlashi mumkin.