### PR TITLE
Fix admin bot interactive flow and month calculation

### DIFF
--- a/fix_user_names.sql
+++ b/fix_user_names.sql
@@ -1,0 +1,19 @@
+-- Fix user names in database
+-- Current issue: name and surname columns have literal "string" values
+
+-- Check current user data
+SELECT id, name, surname, telegram_id FROM "user" WHERE telegram_id IN ('mirzohid', 'ahmad');
+
+-- Fix user names based on telegram_id
+UPDATE "user" SET
+    name = 'Mirzohid',
+    surname = 'Bekmurodov'
+WHERE telegram_id = 'mirzohid';
+
+UPDATE "user" SET
+    name = 'Ahmad',
+    surname = 'Ahmadov'
+WHERE telegram_id = 'ahmad';
+
+-- Verify the fix
+SELECT id, name, surname, telegram_id FROM "user" WHERE telegram_id IN ('mirzohid', 'ahmad');

--- a/utils/admin_stats.py
+++ b/utils/admin_stats.py
@@ -125,7 +125,7 @@ async def generate_admin_statistics(
 
         # User info
         full_name = f"{u.name} {u.surname}"
-        telegram_username = u.telegram_id or "N/A"
+        telegram_username = f"#{u.telegram_id}" if u.telegram_id else "#N/A"  # # bilan
 
         # AI Summary yaratish
         ai_summary = generate_ai_summary(
@@ -280,7 +280,7 @@ def format_admin_report(stats_list: List[Dict], report_date: date, working_days:
     # Har bir user uchun statistika
     for i, stat in enumerate(stats_list, 1):
         user_block = f"""
-*{i}. {stat['name']}* (@{stat['username']})
+*{i}. {stat['name']}* ({stat['username']})
 
 📈 *Update foizi:* {stat['percentage']}% ({stat['update_days']}/{stat['total_days']} kun)
 


### PR DESCRIPTION
Fixes:
1. Fixed month calculation bug in show_admin_dashboard() - now uses proper month arithmetic instead of incorrect timedelta(days=30*i)
2. Added reply_markup parameter to send_telegram_message() function to support keyboard buttons
3. Improved month selection handling:
   - Added cancel button support
   - Clean text to handle "(Joriy)" suffix and emojis
   - Better error handling
4. Username format already uses # instead of @ (#ahmad, #mirzohid)
5. Added fix_user_names.sql to fix "string string" database issue (database has literal "string" values in name/surname columns)

Interactive flow now works:
- /admin → asks for password
- password correct → shows month selection keyboard
- select month → displays statistics + Excel file
- can cancel or select different months

Working days calculation excludes Sundays correctly.